### PR TITLE
added 4-digit resistor naming scheme to ATXBreakoutBoardSMD

### DIFF
--- a/ATXBreakoutBoardSMD/README.md
+++ b/ATXBreakoutBoardSMD/README.md
@@ -10,15 +10,14 @@ A handy breakout board to get all important voltages from an standard ATX power 
 
 | Quantity | Name               | Description                           | Signing/Colorcode | 
 |----------|--------------------|---------------------------------------|-------------------| 
-|          |                    |                                       |                   | 
-| 3        | R1, R3, R7         | 3.3 k ohm 0805 resistor               | 332               | 
-| 1        | R2                 | 330  ohm 0805 resistor                | 331               | 
-| 3        | R4, R5, R6         | 1.2 k ohm 0805 resistor               | 122               | 
-| 1        | R8                 | 10 k ohm 0805 resistor                | 103               | 
+| 3        | R1, R3, R7         | 3.3 k ohm 0805 resistor               | 3301 or 332       | 
+| 1        | R2                 | 330  ohm 0805 resistor                | 3300 or 331       | 
+| 3        | R4, R5, R6         | 1.2 k ohm 0805 resistor               | 1201 or 122       | 
+| 1        | R8                 | 10 k ohm 0805 resistor                | 1002 or 103       | 
 | 1        | R9                 | 9  ohm 10 W power resistor (optional) |                   | 
-| 2        | R10, R15           | 43 k ohm 0805 resistor                | 433               | 
+| 2        | R10, R15           | 43 k ohm 0805 resistor                | 4302 or 433       | 
 | 4        | R12, R14, R17, R19 | 51 k ohm 0805 resistor                | 5102 or 513       | 
-| 2        | R11, R16           | 75 k ohm 0805 resistor                | 753               | 
+| 2        | R11, R16           | 75 k ohm 0805 resistor                | 7502 or 753       | 
 | 2        | C1,C3              | 0.1 uF 0805 SMD capacitor             | red stripe        | 
 | 1        | C2                 | 1 uF 0805 SMD capacitor               | blue stripe       | 
 | 6        | LED1, LED3--LED7   | 0805 SMD LED red                      |                   | 

--- a/ATXBreakoutBoardSMD/manual/configuration/de_parts.csv
+++ b/ATXBreakoutBoardSMD/manual/configuration/de_parts.csv
@@ -1,13 +1,13 @@
 Menge,Name,Beschreibung,Beschriftung/Farbcode
 ,,,
-3,R1{,} R3{,} R7,\SI{3.3}{\kilo\ohm} 0805 Widerstand,332
-1,R2,\SI{330}{\ohm} 0805 Widerstand,331
-3,R4{,} R5{,} R6,\SI{1.2}{\kilo\ohm} 0805 Widerstand,122
-1,R8,\SI{10}{\kilo\ohm} 0805 Widerstand,103
+3,R1{,} R3{,} R7,\SI{3.3}{\kilo\ohm} 0805 Widerstand,3301 oder 332
+1,R2,\SI{330}{\ohm} 0805 Widerstand,3300 oder 331
+3,R4{,} R5{,} R6,\SI{1.2}{\kilo\ohm} 0805 Widerstand,1201 oder 122
+1,R8,\SI{10}{\kilo\ohm} 0805 Widerstand,1002 oder 103
 1,R9,\SI{9}{\ohm} \SI{10}{\W} Power Widerstand (optional),
-2,R10{,} R15,\SI{43}{\kilo\ohm} 0805 Widerstand,433
-4,R12{,} R14{,} R17{,} R19,\SI{51}{\kilo\ohm} 0805 Widerstand,5102 or 513
-2,R11{,} R16,\SI{75}{\kilo\ohm} 0805 Widerstand,753
+2,R10{,} R15,\SI{43}{\kilo\ohm} 0805 Widerstand,4302 oder 433
+4,R12{,} R14{,} R17{,} R19,\SI{51}{\kilo\ohm} 0805 Widerstand,5102 oder 513
+2,R11{,} R16,\SI{75}{\kilo\ohm} 0805 Widerstand,7502 oder 753
 2,C1{,}C3,\SI{0.1}{\mu\farad} 0805 SMD Kondensator,roter Streifen
 1,C2,\SI{1}{\mu\farad} 0805 SMD Kondensator,blauer Streifen
 6,LED1{,} LED3--LED7,0805 SMD LED rot,

--- a/ATXBreakoutBoardSMD/manual/configuration/en_parts.csv
+++ b/ATXBreakoutBoardSMD/manual/configuration/en_parts.csv
@@ -1,13 +1,13 @@
 Quantity,Name,Description,Signing/Colorcode
 ,,,
-3,R1{,} R3{,} R7,\SI{3.3}{\kilo\ohm} 0805 resistor,332
-1,R2,\SI{330}{\ohm} 0805 resistor,331
-3,R4{,} R5{,} R6,\SI{1.2}{\kilo\ohm} 0805 resistor,122
-1,R8,\SI{10}{\kilo\ohm} 0805 resistor,103
+3,R1{,} R3{,} R7,\SI{3.3}{\kilo\ohm} 0805 resistor,3301 or 332
+1,R2,\SI{330}{\ohm} 0805 resistor,3300 or 331
+3,R4{,} R5{,} R6,\SI{1.2}{\kilo\ohm} 0805 resistor,1201 or 122
+1,R8,\SI{10}{\kilo\ohm} 0805 resistor,1002 or 103
 1,R9,\SI{9}{\ohm} \SI{10}{\W} power resistor (optional),
-2,R10{,} R15,\SI{43}{\kilo\ohm} 0805 resistor,433
+2,R10{,} R15,\SI{43}{\kilo\ohm} 0805 resistor,4302 or 433
 4,R12{,} R14{,} R17{,} R19,\SI{51}{\kilo\ohm} 0805 resistor,5102 or 513
-2,R11{,} R16,\SI{75}{\kilo\ohm} 0805 resistor,753
+2,R11{,} R16,\SI{75}{\kilo\ohm} 0805 resistor,7502 or 753
 2,C1{,}C3,\SI{0.1}{\mu\farad} 0805 SMD capacitor,red stripe
 1,C2,\SI{1}{\mu\farad} 0805 SMD capacitor,blue stripe
 6,LED1{,} LED3--LED7,0805 SMD LED red,


### PR DESCRIPTION
Some of the resistors from Blinkyparts were in the 4-digit naming scheme. Therefore I added them to the manual.